### PR TITLE
further warning about disabling background apps

### DIFF
--- a/Win10.ps1
+++ b/Win10.ps1
@@ -238,6 +238,7 @@ Function EnableAppSuggestions {
 }
 
 # Disable Background application access - Ie. if apps can download or update even when they aren't used, affects also start menu tiles
+# Also affects start menu searching!  See here:   https://superuser.com/a/1208858/810129
 Function DisableBackgroundApps {
 	Write-Host "Disabling Background application access..."
 	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Name "GlobalUserDisabled" -Type DWord -Value 1


### PR DESCRIPTION
Pressing the Win Key and typing to search your start menu is an extremely common scenario. For some reason, disabling the "Let apps run in background" breaks this functionality. Re-allowing background apps and rebooting solved it for me. 

I found the answer here:
https://superuser.com/a/1208858/810129