### PR TITLE
Enable Classic Control Panel (Windows 7 style)

### DIFF
--- a/Win10.ps1
+++ b/Win10.ps1
@@ -92,6 +92,7 @@ $tweaks = @(
 	"DisableThumbsDB",              # "EnableThumbsDB",
 	# "AddENKeyboard",              # "RemoveENKeyboard",
 	# "EnableNumlock",              # "DisableNumlock",
+	"EnableClassicControlPanel",    # "DisableClassicControlPanel",
 
 	### Application Tweaks ###
 	"DisableOneDrive",              # "EnableOneDrive",
@@ -1364,6 +1365,20 @@ Function DisableNumlock {
 		$wsh = New-Object -ComObject WScript.Shell
 		$wsh.SendKeys('{NUMLOCK}')
 	}
+}
+# Enable Classic Control Panel (Windows 7 style)
+Function EnableClassicControlPanel {
+	Write-Host "Enabling Classic Control Panel (Windows 7 style)..."
+	If (!(Test-Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer")) {
+		New-Item -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" | Out-Null
+	}
+	Set-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "ForceClassicControlPanel" -Type DWord -Value 1
+}
+
+# Disable Classic Control Panel (Windows 7 style)
+Function DisableClassicControlPanel {
+	Write-Host "Disabling Classic Control Panel (Windows 7 style)..."
+	Remove-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "ForceClassicControlPanel" -ErrorAction SilentlyContinue
 }
 
 


### PR DESCRIPTION
This shows the classic Control Panel as icons instead of grouped. Useful for old-timers like me.

(This is my first PR ever, so please forgive me if I'm not doing this right.)