### PR TITLE
Add function to install Chocolatey

### DIFF
--- a/Win10.ps1
+++ b/Win10.ps1
@@ -123,6 +123,9 @@ $tweaks = @(
 	"EnableF8BootMenu",             # "DisableF8BootMenu",
 	"SetDEPOptOut",                 # "SetDEPOptIn",
 
+	### 3rd Party Softare ###
+	# "InstallChocolatey",            # "UninstallChocolatey",
+
 	### Server Specific Tweaks ###
 	# "HideServerManagerOnLogin",   # "ShowServerManagerOnLogin",
 	# "DisableShutdownTracker",     # "EnableShutdownTracker",
@@ -1971,6 +1974,25 @@ Function SetDEPOptOut {
 Function SetDEPOptIn {
 	Write-Host "Setting Data Execution Prevention (DEP) policy to OptIn..."
 	bcdedit /set `{current`} nx OptIn | Out-Null
+}
+
+
+
+##########
+# 3rd Party Software
+##########
+
+# Install Chocolatey from remote
+Function InstallChocolatey {
+    Write-Host "Downloading and running Chocolatey installation script"
+    # ExecutionPolicy should already be Bypass
+    iex ((New-Object System.Net.WebClient).DownloadString("https://chocolatey.org/install.ps1"))
+}
+
+# Remove Chocolatey from local machine
+Function UninstallChocolatey {
+    Write-Host "Removing Chocolatey directory"
+    Remove-Item "c:\ProgramData\Chocolatey" -Recurse -Force
 }
 
 


### PR DESCRIPTION
I think some people prefer to install this script from choco, rather than the other way around, but that makes it harder to tweak this.

As installing choco is something I do on every Win10 setup, it makes sense to me to have that in a Win10 initial setup script. You might consider this out of scope as the rest of the script doesn't touch 3rd-party stuff that isn't already installed, but imho it's an important tool.