### PR TITLE
Enable strong cryptography on .Net Framework

### DIFF
--- a/Win10.ps1
+++ b/Win10.ps1
@@ -718,14 +718,18 @@ Function DisableMeltdownCompatFlag {
 # https://stackoverflow.com/questions/36265534/invoke-webrequest-ssl-fails
 function EnableDotNetStrongCrypto {
     Write-output "Enabling .NET strong cryptography"
-    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -Value '1' -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -Value '1' -Type DWord -ErrorAction SilentlyContinue
+    If (Test-Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319") {
+        Set-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319" -Name "SchUseStrongCrypto" -Value "1" -Type DWord -ErrorAction SilentlyContinue
+    }
+    Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\.NetFramework\v4.0.30319" -Name "SchUseStrongCrypto" -Value "1" -Type DWord -ErrorAction SilentlyContinue
 }
 # Disable strong cryptography for .Net Framework (version 4 and above)
 function DisableDotNetStrongCrypto {
     Write-output "Disabling .NET strong cryptography"
-    Remove-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -ErrorAction SilentlyContinue
-    Remove-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -ErrorAction SilentlyContinue
+    If (Test-Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319") {
+        Remove-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319" -Name "SchUseStrongCrypto" -ErrorAction SilentlyContinue
+    }
+    Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\.NetFramework\v4.0.30319" -Name "SchUseStrongCrypto" -ErrorAction SilentlyContinue
 }
 
 

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -45,6 +45,7 @@ $tweaks = @(
 	"SetDEPOptOut",                 # "SetDEPOptIn",
 	"DisableScriptHost",            # "EnableScriptHost",
 	# "EnableMeltdownCompatFlag"    # "DisableMeltdownCompatFlag",
+	"EnableDotNetStrongCrypto",     # "DisableDotNetStrongCrypto",
 
 	### Service Tweaks ###
 	# "DisableUpdateMSRT",          # "EnableUpdateMSRT",
@@ -713,6 +714,19 @@ Function DisableMeltdownCompatFlag {
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\QualityCompat" -Name "cadca5fe-87d3-4b96-b7fb-a231484277cc" -ErrorAction SilentlyContinue
 }
 
+# Enable strong cryptography for .Net Framework (version 4 and above)
+# https://stackoverflow.com/questions/36265534/invoke-webrequest-ssl-fails
+function EnableDotNetStrongCrypto {
+    Write-output "Enabling .NET strong cryptography"
+    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -Value '1' -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -Value '1' -Type DWord -ErrorAction SilentlyContinue
+}
+# Disable strong cryptography for .Net Framework (version 4 and above)
+function DisableDotNetStrongCrypto {
+    Write-output "Disabling .NET strong cryptography"
+    Remove-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -ErrorAction SilentlyContinue
+    Remove-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -ErrorAction SilentlyContinue
+}
 
 
 ##########


### PR DESCRIPTION
by default invoke-webrequest uses Tls1.0 or Tls1.1 which is deprecated and mostly turned off on remote locations