### PR TITLE
Remove prompt when stopping OneDrive service

### DIFF
--- a/Win10.ps1
+++ b/Win10.ps1
@@ -1826,7 +1826,7 @@ Function EnableOneDrive {
 # Uninstall OneDrive - Not applicable to Server
 Function UninstallOneDrive {
 	Write-Output "Uninstalling OneDrive..."
-	Stop-Process -Name "OneDrive" -ErrorAction SilentlyContinue
+	Stop-Process -Name "OneDrive" -Force -ErrorAction SilentlyContinue
 	Start-Sleep -s 2
 	$onedrive = "$env:SYSTEMROOT\SysWOW64\OneDriveSetup.exe"
 	If (!(Test-Path $onedrive)) {


### PR DESCRIPTION
When trying to stop the OneDrive service before uninstall, powershell ask for confirmation.
By forcing the confirmation is removed.

Modified as shown in example 4 for the [Stop-Process documentation](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-process?view=powershell-6#examples) 