### PR TITLE
Split DisableThumbsDB

### DIFF
--- a/Default.preset
+++ b/Default.preset
@@ -103,7 +103,8 @@ HideVideosFromThisPC
 Hide3DObjectsFromThisPC
 # Hide3DObjectsFromExplorer
 # DisableThumbnails
-DisableThumbsDB
+DisableThumbnailCache
+DisableThumbsDBOnNetwork
 
 DisableOneDrive
 UninstallOneDrive

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -116,7 +116,8 @@ $tweaks = @(
 	"Hide3DObjectsFromThisPC",      # "Show3DObjectsInThisPC",
 	# "Hide3DObjectsFromExplorer",  # "Show3DObjectsInExplorer",
 	# "DisableThumbnails",          # "EnableThumbnails",
-	"DisableThumbsDB",              # "EnableThumbsDB",
+	"DisableThumbnailCache",        # "EnableThumbnailCache",
+	"DisableThumbsDBOnNetwork",     # "EnableThumbsDBOnNetwork",
 
 	### Application Tweaks ###
 	"DisableOneDrive",              # "EnableOneDrive",
@@ -1797,17 +1798,27 @@ Function EnableThumbnails {
 	Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "IconsOnly" -Type DWord -Value 0
 }
 
-# Disable creation of Thumbs.db thumbnail cache files
-Function DisableThumbsDB {
-	Write-Output "Disabling creation of Thumbs.db..."
+# Disable creation of thumbnail cache files
+Function DisableThumbnailCache {
+	Write-Output "Disabling creation of thumbnail cache files..."
 	Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbnailCache" -Type DWord -Value 1
+}
+
+# Enable creation of thumbnail cache files
+Function EnableThumbnailCache {
+	Write-Output "Enabling creation of thumbnail cache files..."
+	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbnailCache" -ErrorAction SilentlyContinue
+}
+
+# Disable creation of Thumbs.db thumbnail cache files on network folders
+Function DisableThumbsDBOnNetwork {
+	Write-Output "Disabling creation of Thumbs.db on network folders..."
 	Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbsDBOnNetworkFolders" -Type DWord -Value 1
 }
 
-# Enable creation of Thumbs.db thumbnail cache files
-Function EnableThumbsDB {
-	Write-Output "Enable creation of Thumbs.db..."
-	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbnailCache" -ErrorAction SilentlyContinue
+# Enable creation of Thumbs.db thumbnail cache files on network folders
+Function EnableThumbsDBOnNetwork {
+	Write-Output "Enabling creation of Thumbs.db on network folders..."
 	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbsDBOnNetworkFolders" -ErrorAction SilentlyContinue
 }
 


### PR DESCRIPTION
Issued @ #85
- allows to control db creation on local and net folders separately
- tried to make function names more fitting
- updated descriptions
- changed Enable to Enabling for output based on other tweaks convention