### PR TITLE
Add "Uninstall Windows Fax and Scan Services"

### DIFF
--- a/Default.preset
+++ b/Default.preset
@@ -127,6 +127,7 @@ AddPhotoViewerOpenWith
 # UninstallPDFPrinter
 UninstallXPSPrinter
 RemoveFaxPrinter
+# UninstallFaxAndScanServices
 
 # HideServerManagerOnLogin
 # DisableShutdownTracker

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -141,6 +141,7 @@ $tweaks = @(
 	# "UninstallPDFPrinter",        # "InstallPDFPrinter",
 	"UninstallXPSPrinter",          # "InstallXPSPrinter",
 	"RemoveFaxPrinter",             # "AddFaxPrinter",
+	# "UninstallFaxAndScanServices",# "InstallFaxAndScanServices",
 
 	### Server Specific Tweaks ###
 	# "HideServerManagerOnLogin",   # "ShowServerManagerOnLogin",
@@ -2326,6 +2327,18 @@ Function RemoveFaxPrinter {
 Function AddFaxPrinter {
 	Write-Output "Adding Default Fax Printer..."
 	Add-Printer -Name "Fax" -DriverName "Microsoft Shared Fax Driver" -PortName "SHRFAX:" -ErrorAction SilentlyContinue
+}
+
+# Uninstall Windows Fax and Scan Services
+Function UninstallFaxAndScanServices {
+	Write-Output "Uninstalling Windows Fax and Scan Services..."
+	Disable-WindowsOptionalFeature -Online -FeatureName "FaxServicesClientPackage" -NoRestart -WarningAction SilentlyContinue | Out-Null
+}
+
+# Install Windows Fax and Scan Services
+Function InstallFaxAndScanServices {
+	Write-Output "Installing Windows Fax and Scan Services..."
+	Enable-WindowsOptionalFeature -Online -FeatureName "FaxServicesClientPackage" -NoRestart -WarningAction SilentlyContinue | Out-Null
 }
 
 


### PR DESCRIPTION
In addition to (or instead of) removing the fax printer ("RemoveFaxPrinter" fix), this allows completely uninstalling the Fax and Scan services.