### PR TITLE
Use absolute paths in Default.cmd file

### DIFF
--- a/Default.cmd
+++ b/Default.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Win10.ps1" -preset "Default.preset"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Win10.ps1" -preset "%~dpn0.preset"

--- a/Default.cmd
+++ b/Default.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "Win10.ps1" -preset "Default.preset"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Win10.ps1" -preset "Default.preset"


### PR DESCRIPTION
This PR serves two purposes:

- Use absolute path to Win10.ps1 in Default.cmd to allow launching the script from a differing working directory.
- Use "%~dpn0.preset" instead of "Default.preset" to allow duplicating the Default.cmd file to launch a custom preset file without modifications. The cmd file will always load the preset file with the same as the cmd file.