### PR TITLE
Add sound scheme related tweaks

### DIFF
--- a/Default.preset
+++ b/Default.preset
@@ -82,6 +82,9 @@ DisableNewAppPrompt
 SetVisualFXPerformance
 # AddENKeyboard
 # EnableNumlock
+# SetSoundSchemeNone
+# DisableStartupSound
+# DisableChangingSoundScheme
 
 ShowKnownExtensions
 ShowHiddenFiles

--- a/Default.preset
+++ b/Default.preset
@@ -103,7 +103,8 @@ HideVideosFromThisPC
 Hide3DObjectsFromThisPC
 # Hide3DObjectsFromExplorer
 # DisableThumbnails
-DisableThumbsDB
+DisableThumbnailCache
+DisableThumbsDBOnNetwork
 
 DisableOneDrive
 UninstallOneDrive

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -1496,6 +1496,7 @@ Function DisableNumlock {
 	}
 }
 
+# Set sound scheme to No Sounds
 Function SetSoundSchemeNone {
 	Write-Output "Setting sound scheme to No Sounds..."
 	$SoundScheme = ".None"

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -94,6 +94,9 @@ $tweaks = @(
 	"SetVisualFXPerformance",       # "SetVisualFXAppearance",
 	# "AddENKeyboard",              # "RemoveENKeyboard",
 	# "EnableNumlock",              # "DisableNumlock",
+	# "SetSoundSchemeNone",         # "SetSoundSchemeDefault",
+	# "DisableStartupSound",        # "EnableStartupSound",
+	# "DisableChangingSoundScheme", # "EnableChangingSoundScheme",
 
 	### Explorer UI Tweaks ###
 	"ShowKnownExtensions",          # "HideKnownExtensions",
@@ -1493,7 +1496,75 @@ Function DisableNumlock {
 	}
 }
 
+Function SetSoundSchemeNone {
+	Write-Output "Setting sound scheme to No Sounds..."
+	$SoundScheme = ".None"
+	Get-ChildItem -Path "HKCU:\AppEvents\Schemes\Apps\*\*" | ForEach {
+		# If scheme keys do not exist in an event, create empty ones (similar behavior to Sound control panel).
+		If (!(Test-Path "$($_.PsPath)\$($SoundScheme)")) {
+			New-Item -Path "$($_.PsPath)\$($SoundScheme)" | Out-Null
+		}
+		If (!(Test-Path "$($_.PsPath)\.Current")) {
+			New-Item -Path "$($_.PsPath)\.Current" | Out-Null
+		}
+		# Get a regular string from any possible kind of value, i.e. resolve REG_EXPAND_SZ, copy REG_SZ or empty from non-existing.
+		$Data = (Get-ItemProperty -Path "$($_.PsPath)\$($SoundScheme)" -Name "(Default)" -ErrorAction SilentlyContinue)."(Default)"
+		# Replace any kind of value with a regular string (similar behavior to Sound control panel).
+		Set-ItemProperty -Path "$($_.PsPath)\$($SoundScheme)" -Name "(Default)" -Type String -Value $Data
+		# Copy data from source scheme to current.
+		Set-ItemProperty -Path "$($_.PsPath)\.Current" -Name "(Default)" -Type String -Value $Data
+	}
+	Set-ItemProperty -Path "HKCU:\AppEvents\Schemes" -Name "(Default)" -Type String -Value $SoundScheme
+}
 
+# Set sound scheme to Windows Default
+Function SetSoundSchemeDefault {
+	Write-Output "Setting sound scheme to Windows Default..."
+	$SoundScheme = ".Default"
+	Get-ChildItem -Path "HKCU:\AppEvents\Schemes\Apps\*\*" | ForEach {
+		# If scheme keys do not exist in an event, create empty ones (similar behavior to Sound control panel).
+		If (!(Test-Path "$($_.PsPath)\$($SoundScheme)")) {
+			New-Item -Path "$($_.PsPath)\$($SoundScheme)" | Out-Null
+		}
+		If (!(Test-Path "$($_.PsPath)\.Current")) {
+			New-Item -Path "$($_.PsPath)\.Current" | Out-Null
+		}
+		# Get a regular string from any possible kind of value, i.e. resolve REG_EXPAND_SZ, copy REG_SZ or empty from non-existing.
+		$Data = (Get-ItemProperty -Path "$($_.PsPath)\$($SoundScheme)" -Name "(Default)" -ErrorAction SilentlyContinue)."(Default)"
+		# Replace any kind of value with a regular string (similar behavior to Sound control panel).
+		Set-ItemProperty -Path "$($_.PsPath)\$($SoundScheme)" -Name "(Default)" -Type String -Value $Data
+		# Copy data from source scheme to current.
+		Set-ItemProperty -Path "$($_.PsPath)\.Current" -Name "(Default)" -Type String -Value $Data
+	}
+	Set-ItemProperty -Path "HKCU:\AppEvents\Schemes" -Name "(Default)" -Type String -Value $SoundScheme
+}
+
+# Disable playing Windows Startup sound
+Function DisableStartupSound {
+	Write-Output "Disabling Windows Startup sound..."
+	Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI\BootAnimation" -Name "DisableStartupSound" -Type DWord -Value 1
+}
+
+# Enable playing Windows Startup sound
+Function EnableStartupSound {
+	Write-Output "Enabling Windows Startup sound..."
+	Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI\BootAnimation" -Name "DisableStartupSound" -Type DWord -Value 0
+}
+
+# Disable changing sound scheme
+Function DisableChangingSoundScheme {
+	Write-Output "Disabling changing sound scheme..."
+	If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Personalization")) {
+		New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Personalization" -Force | Out-Null
+	}
+	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Personalization" -Name "NoChangingSoundScheme" -Type DWord -Value 1
+}
+
+# Enable changing sound scheme
+Function EnableChangingSoundScheme {
+	Write-Output "Enabling changing sound scheme..."
+	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Personalization" -Name "NoChangingSoundScheme" -ErrorAction SilentlyContinue
+}
 
 ##########
 # Explorer UI Tweaks

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -116,7 +116,8 @@ $tweaks = @(
 	"Hide3DObjectsFromThisPC",      # "Show3DObjectsInThisPC",
 	# "Hide3DObjectsFromExplorer",  # "Show3DObjectsInExplorer",
 	# "DisableThumbnails",          # "EnableThumbnails",
-	"DisableThumbsDB",              # "EnableThumbsDB",
+	"DisableThumbnailCache",        # "EnableThumbnailCache",
+	"DisableThumbsDBOnNetwork",     # "EnableThumbsDBOnNetwork",
 
 	### Application Tweaks ###
 	"DisableOneDrive",              # "EnableOneDrive",
@@ -1797,17 +1798,27 @@ Function EnableThumbnails {
 	Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "IconsOnly" -Type DWord -Value 0
 }
 
-# Disable creation of Thumbs.db thumbnail cache files
-Function DisableThumbsDB {
-	Write-Output "Disabling creation of Thumbs.db..."
+# Disable creation of thumbnail cache files
+Function DisableThumbnailCache {
+	Write-Output "Disabling creation of thumbnail cache files..."
 	Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbnailCache" -Type DWord -Value 1
+}
+
+# Enable creation of thumbnail cache files
+Function EnableThumbnailCache {
+	Write-Output "Enabling creation of thumbnail cache files..."
+	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbnailCache" -ErrorAction SilentlyContinue
+}
+
+# Disable creation of Thumbs.db thumbnail cache files on network folders
+Function DisableThumbsDBOnNetwork {
+	Write-Output "Disabling creation of Thumbs.db on network folders..."
 	Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbsDBOnNetworkFolders" -Type DWord -Value 1
 }
 
-# Enable creation of Thumbs.db thumbnail cache files
-Function EnableThumbsDB {
-	Write-Output "Enable creation of Thumbs.db..."
-	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbnailCache" -ErrorAction SilentlyContinue
+# Enable creation of Thumbs.db thumbnail cache files on network folders
+Function EnableThumbsDBOnNetwork {
+	Write-Output "Enabling creation of Thumbs.db on network folders..."
 	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "DisableThumbsDBOnNetworkFolders" -ErrorAction SilentlyContinue
 }
 


### PR DESCRIPTION
Instead of preparing for exams, I was procrastinating and managed how to control Windows' sound schemes by using a script. There are six new functions, all tested and working in Win10 Pro 1803, Win10 EntLTSB 1607 and Win7 Pro SP1. 😄 
**DisableChangingSoundScheme / EnableChangingSoundScheme**: Prevents/allows users from changing sound scheme via control panel (hides Sounds tab). GPO applied under HKLM to affect all users.
**DisableStartupSound / EnableStartupSound**: Applied under HKLM for all users (not GPO), switches exactly what "Play Windows Startup sound" checkbox in control panel does.
**SetSoundSchemeNone / SetSoundSchemeDefault**: These are my favorites and SetSoundSchemeNone is the reason why this pull has been developed - to have ability to programatically mute all the stupid sounds everywhere I go. :smile: I tracked what control panel does and simulated it's funny behavior. See comments directly in the code for details and also pls check grammar if you accept the request as is or at all.