### PR TITLE
Add "DisableNetConnectionTest" and "SetMozillaForNetConnTest"

### DIFF
--- a/Default.preset
+++ b/Default.preset
@@ -20,6 +20,8 @@ DisableErrorReporting
 # SetP2PUpdateLocal
 DisableDiagTrack
 DisableWAPPush
+DisableNetConnectionTest
+# SetMozillaForNetConnTest
 
 # SetUACLow
 # EnableSharingMappedDrives

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -29,6 +29,8 @@ $tweaks = @(
 	# "SetP2PUpdateLocal",          # "SetP2PUpdateInternet",
 	"DisableDiagTrack",             # "EnableDiagTrack",
 	"DisableWAPPush",               # "EnableWAPPush",
+	"DisableNetConnectionTest",     # "EnablenNetConnectionTest",
+	# "SetMozillaForNetConnTest",  	# "SetMicrosoftForNetConnTest",
 
 	### Security Tweaks ###
 	# "SetUACLow",                  # "SetUACHigh",
@@ -528,6 +530,37 @@ Function EnableWAPPush {
 	Start-Service "dmwappushservice" -WarningAction SilentlyContinue
 	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\dmwappushservice" -Name "DelayedAutoStart" -Type DWord -Value 1
 }
+
+# Disable Network Connection test (www.msftconnecttest.com)
+Function DisableNetConnectionTest {
+	Write-Output "Disabling Network Connection test..."
+	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet" -Name "EnableActiveProbing" -Type DWord -Value 0
+}
+
+# Enable Network Connection test
+Function EnableNetConnectionTest {
+	Write-Output "Enabling Network Connection test..."
+	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet" -Name "EnableActiveProbing" -Type DWord -Value 1
+}
+
+# Use Mozilla's servers instead of Microsoft's ones for Network Connection test (if it is enabled)
+Function SetMozillaForNetConnTest {
+	Write-Output "Setting Mozilla servers for Network Connection test..."
+	# TODO: add IPV6
+	# TODO: add DNS
+	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet" -Name "ActiveWebProbeHost" -Type ExpandString -Value "detectportal.firefox.com"
+	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet" -Name "ActiveWebProbePath" -Type ExpandString -Value "success.txt"
+	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet" -Name "ActiveWebProbeContent" -Type ExpandString -Value "success"
+}
+
+# Use Microsoft's servers for Network Connection test (if it is enabled)
+Function SetMicrosoftForNetConnTest {
+	Write-Output "Setting Mozilla servers for Network Connection test..."
+	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet" -Name "ActiveWebProbeHost" -Type ExpandString -Value "www.msftconnecttest.com"
+	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet" -Name "ActiveWebProbePath" -Type ExpandString -Value "connecttest.txt"
+	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet" -Name "ActiveWebProbeContent" -Type ExpandString -Value "Microsoft Connect Test"
+}
+
 
 
 


### PR DESCRIPTION
Disabling Network Connection test (a.k.a. NCSI , Network Connection Status Icon) prevents your computer to send DNS and HTTP requests to Microsoft's servers as soon as you are connected to any Network.

Note that "SetMozzillaForNetConnTest" is not granting you any privacy (yet).
The right method would be to setup your own NCSI server since, as far as I know, there isn't a public "privacy aware" one.

In any case, disabling NCSI should be enough of a precaution.