### PR TITLE
Add Explorer and Start Menu tweaks

### DIFF
--- a/Default.preset
+++ b/Default.preset
@@ -20,6 +20,8 @@ DisableErrorReporting
 # SetP2PUpdateLocal
 DisableDiagTrack
 DisableWAPPush
+# HideRecentlyAddedApps
+# HideRecentJumplists
 
 # SetUACLow
 # EnableSharingMappedDrives

--- a/Default.preset
+++ b/Default.preset
@@ -20,7 +20,6 @@ DisableErrorReporting
 # SetP2PUpdateLocal
 DisableDiagTrack
 DisableWAPPush
-# HideRecentlyAddedApps
 # HideRecentJumplists
 
 # SetUACLow
@@ -81,6 +80,7 @@ HideTaskbarPeopleIcon
 ShowTrayIcons
 DisableSearchAppInStore
 DisableNewAppPrompt
+# HideRecentlyAddedApps
 # SetControlPanelSmallIcons
 SetVisualFXPerformance
 # AddENKeyboard
@@ -91,8 +91,8 @@ SetVisualFXPerformance
 
 ShowKnownExtensions
 ShowHiddenFiles
-# EnableFolderSeparateProcess
-# EnableRestoreFolderWindows
+# EnableFldrSeparateProcess
+# EnableRestoreFldrWindows
 # DisableSharingWizard
 HideSelectCheckboxes
 HideSyncNotifications

--- a/Default.preset
+++ b/Default.preset
@@ -89,6 +89,9 @@ SetVisualFXPerformance
 
 ShowKnownExtensions
 ShowHiddenFiles
+# EnableFolderSeparateProcess
+# EnableRestoreFolderWindows
+# DisableSharingWizard
 HideSelectCheckboxes
 HideSyncNotifications
 HideRecentShortcuts

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -29,6 +29,8 @@ $tweaks = @(
 	# "SetP2PUpdateLocal",          # "SetP2PUpdateInternet",       # "SetP2PUpdateDisable",
 	"DisableDiagTrack",             # "EnableDiagTrack",
 	"DisableWAPPush",               # "EnableWAPPush",
+	"HideRecentlyAddedApps",        # "ShowRecentlyAddedApps",
+	"HideRecentJumplists",          # "ShowRecentJumplists",
 
 	### Security Tweaks ###
 	# "SetUACLow",                  # "SetUACHigh",
@@ -580,6 +582,33 @@ Function EnableWAPPush {
 	Set-Service "dmwappushservice" -StartupType Automatic
 	Start-Service "dmwappushservice" -WarningAction SilentlyContinue
 	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\dmwappushservice" -Name "DelayedAutoStart" -Type DWord -Value 1
+}
+
+# Hide "Recently added" list from Start Menu
+Function HideRecentlyAddedApps {
+	Write-Output "Hiding 'Recently added' list from Start Menu..."
+	If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer")) {
+		New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" | Out-Null
+	}
+	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideRecentlyAddedApps" -Type DWord -Value 1
+}
+
+# Show "Recently added" list in Start Menu
+Function ShowRecentlyAddedApps {
+	Write-Output "Showing 'Recently added' list in Start Menu..."
+	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideRecentlyAddedApps" -ErrorAction SilentlyContinue
+}
+
+# Hide recently opened items in Jump Lists on Start or the taskbar
+Function HideRecentJumplists {
+	Write-Output "Hiding recently opened items in Jump Lists..."
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "Start_TrackDocs" -Type DWord -Value 0
+}
+
+# Show recently opened items in Jump Lists on Start or the taskbar
+Function ShowRecentJumplists {
+	Write-Output "Showing recently opened items in Jump Lists..."
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "Start_TrackDocs" -Type DWord -Value 1
 }
 
 

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -102,6 +102,9 @@ $tweaks = @(
 	### Explorer UI Tweaks ###
 	"ShowKnownExtensions",          # "HideKnownExtensions",
 	"ShowHiddenFiles",              # "HideHiddenFiles",
+	# "EnableFolderSeparateProcess" # "DisableFolderSeparateProcess",
+	# "EnableRestoreFolderWindows"  # "DisableRestoreFolderWindows",
+	# "DisableSharingWizard",       # "EnableSharingWizard",
 	# "HideSelectCheckboxes",       # "ShowSelectCheckboxes",
 	"HideSyncNotifications"         # "ShowSyncNotifications",
 	"HideRecentShortcuts",          # "ShowRecentShortcuts",
@@ -1657,6 +1660,42 @@ Function ShowHiddenFiles {
 Function HideHiddenFiles {
 	Write-Output "Hiding hidden files..."
 	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "Hidden" -Type DWord -Value 2
+}
+
+# Enable launching folder windows in a separate process
+Function EnableFolderSeparateProcess {
+	Write-Output "Enabling launching folder windows in a separate process..."
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "SeparateProcess" -Type DWord -Value 1
+}
+
+# Disable launching folder windows in a separate process
+Function DisableFolderSeparateProcess {
+	Write-Output "Disabling launching folder windows in a separate process..."
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "SeparateProcess" -Type DWord -Value 0
+}
+
+# Enable restoring previous folder windows at logon
+Function EnableRestoreFolderWindows {
+	Write-Output "Enabling restoring previous folder windows at logon..."
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "PersistBrowsers" -Type DWord -Value 1
+}
+
+# Disable restoring previous folder windows at logon
+Function DisableRestoreFolderWindows {
+	Write-Output "Disabling restoring previous folder windows at logon..."
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "PersistBrowsers" -Type DWord -Value 0
+}
+
+# Disable Sharing Wizard
+Function DisableSharingWizard {
+	Write-Output "Disabling Sharing Wizard..."
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "SharingWizardOn" -Type DWord -Value 0
+}
+
+# Enable Sharing Wizard
+Function EnableSharingWizard {
+	Write-Output "Enabling Sharing Wizard..."
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "SharingWizardOn" -Type DWord -Value 1
 }
 
 # Hide item selection checkboxes

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -52,7 +52,7 @@ $tweaks = @(
 	# "EnableCIMemoryIntegrity",    # "DisableCIMemoryIntegrity",
 	"DisableScriptHost",            # "EnableScriptHost",
 	"EnableDotNetStrongCrypto",     # "DisableDotNetStrongCrypto",
-	# "EnableMeltdownCompatFlag"    # "DisableMeltdownCompatFlag",
+	# "EnableMeltdownCompatFlag",   # "DisableMeltdownCompatFlag",
 
 	### Service Tweaks ###
 	# "DisableUpdateMSRT",          # "EnableUpdateMSRT",
@@ -82,7 +82,7 @@ $tweaks = @(
 	"HideNetworkFromLockScreen",    # "ShowNetworkOnLockScreen",
 	"HideShutdownFromLockScreen",   # "ShowShutdownOnLockScreen",
 	"DisableStickyKeys",            # "EnableStickyKeys",
-	"ShowTaskManagerDetails"        # "HideTaskManagerDetails",
+	"ShowTaskManagerDetails",       # "HideTaskManagerDetails",
 	"ShowFileOperationsDetails",    # "HideFileOperationsDetails",
 	# "EnableFileDeleteConfirm",    # "DisableFileDeleteConfirm",
 	"HideTaskbarSearch",            # "ShowTaskbarSearchIcon",      # "ShowTaskbarSearchBox",
@@ -104,8 +104,8 @@ $tweaks = @(
 	### Explorer UI Tweaks ###
 	"ShowKnownExtensions",          # "HideKnownExtensions",
 	"ShowHiddenFiles",              # "HideHiddenFiles",
-	# "EnableFolderSeparateProcess" # "DisableFolderSeparateProcess",
-	# "EnableRestoreFolderWindows"  # "DisableRestoreFolderWindows",
+	# "EnableFldrSeparateProcess",  # "DisableFldrSeparateProcess",
+	# "EnableRestoreFldrWindows",   # "DisableRestoreFldrWindows",
 	# "DisableSharingWizard",       # "EnableSharingWizard",
 	# "HideSelectCheckboxes",       # "ShowSelectCheckboxes",
 	"HideSyncNotifications"         # "ShowSyncNotifications",
@@ -1662,6 +1662,8 @@ Function EnableChangingSoundScheme {
 	Write-Output "Enabling changing sound scheme..."
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Personalization" -Name "NoChangingSoundScheme" -ErrorAction SilentlyContinue
 }
+
+
 
 ##########
 # Explorer UI Tweaks

--- a/Win10.ps1
+++ b/Win10.ps1
@@ -29,8 +29,7 @@ $tweaks = @(
 	# "SetP2PUpdateLocal",          # "SetP2PUpdateInternet",       # "SetP2PUpdateDisable",
 	"DisableDiagTrack",             # "EnableDiagTrack",
 	"DisableWAPPush",               # "EnableWAPPush",
-	"HideRecentlyAddedApps",        # "ShowRecentlyAddedApps",
-	"HideRecentJumplists",          # "ShowRecentJumplists",
+	# "HideRecentJumplists",        # "ShowRecentJumplists",
 
 	### Security Tweaks ###
 	# "SetUACLow",                  # "SetUACHigh",
@@ -93,6 +92,7 @@ $tweaks = @(
 	"ShowTrayIcons",                # "HideTrayIcons",
 	"DisableSearchAppInStore",      # "EnableSearchAppInStore",
 	"DisableNewAppPrompt",          # "EnableNewAppPrompt",
+	# "HideRecentlyAddedApps",      # "ShowRecentlyAddedApps",
 	# "SetControlPanelSmallIcons",  # "SetControlPanelLargeIcons",  # "SetControlPanelCategories",
 	"SetVisualFXPerformance",       # "SetVisualFXAppearance",
 	# "AddENKeyboard",              # "RemoveENKeyboard",
@@ -584,21 +584,6 @@ Function EnableWAPPush {
 	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\dmwappushservice" -Name "DelayedAutoStart" -Type DWord -Value 1
 }
 
-# Hide "Recently added" list from Start Menu
-Function HideRecentlyAddedApps {
-	Write-Output "Hiding 'Recently added' list from Start Menu..."
-	If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer")) {
-		New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" | Out-Null
-	}
-	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideRecentlyAddedApps" -Type DWord -Value 1
-}
-
-# Show "Recently added" list in Start Menu
-Function ShowRecentlyAddedApps {
-	Write-Output "Showing 'Recently added' list in Start Menu..."
-	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideRecentlyAddedApps" -ErrorAction SilentlyContinue
-}
-
 # Hide recently opened items in Jump Lists on Start or the taskbar
 Function HideRecentJumplists {
 	Write-Output "Hiding recently opened items in Jump Lists..."
@@ -608,7 +593,7 @@ Function HideRecentJumplists {
 # Show recently opened items in Jump Lists on Start or the taskbar
 Function ShowRecentJumplists {
 	Write-Output "Showing recently opened items in Jump Lists..."
-	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "Start_TrackDocs" -Type DWord -Value 1
+	Remove-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "Start_TrackDocs" -ErrorAction SilentlyContinue
 }
 
 
@@ -1492,6 +1477,21 @@ Function EnableNewAppPrompt {
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "NoNewAppAlert" -ErrorAction SilentlyContinue
 }
 
+# Hide "Recently added" list from Start Menu
+Function HideRecentlyAddedApps {
+	Write-Output "Hiding 'Recently added' list from Start Menu..."
+	If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer")) {
+		New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" | Out-Null
+	}
+	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideRecentlyAddedApps" -Type DWord -Value 1
+}
+
+# Show "Recently added" list in Start Menu
+Function ShowRecentlyAddedApps {
+	Write-Output "Showing 'Recently added' list in Start Menu..."
+	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideRecentlyAddedApps" -ErrorAction SilentlyContinue
+}
+
 # Set Control Panel view to Small icons (Classic)
 Function SetControlPanelSmallIcons {
 	Write-Output "Setting Control Panel view to small icons..."
@@ -1694,27 +1694,27 @@ Function HideHiddenFiles {
 }
 
 # Enable launching folder windows in a separate process
-Function EnableFolderSeparateProcess {
+Function EnableFldrSeparateProcess {
 	Write-Output "Enabling launching folder windows in a separate process..."
 	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "SeparateProcess" -Type DWord -Value 1
 }
 
 # Disable launching folder windows in a separate process
-Function DisableFolderSeparateProcess {
+Function DisableFldrSeparateProcess {
 	Write-Output "Disabling launching folder windows in a separate process..."
 	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "SeparateProcess" -Type DWord -Value 0
 }
 
 # Enable restoring previous folder windows at logon
-Function EnableRestoreFolderWindows {
+Function EnableRestoreFldrWindows {
 	Write-Output "Enabling restoring previous folder windows at logon..."
 	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "PersistBrowsers" -Type DWord -Value 1
 }
 
 # Disable restoring previous folder windows at logon
-Function DisableRestoreFolderWindows {
+Function DisableRestoreFldrWindows {
 	Write-Output "Disabling restoring previous folder windows at logon..."
-	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "PersistBrowsers" -Type DWord -Value 0
+	Remove-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "PersistBrowsers" -ErrorAction SilentlyContinue
 }
 
 # Disable Sharing Wizard
@@ -1726,7 +1726,7 @@ Function DisableSharingWizard {
 # Enable Sharing Wizard
 Function EnableSharingWizard {
 	Write-Output "Enabling Sharing Wizard..."
-	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "SharingWizardOn" -Type DWord -Value 1
+	Remove-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "PersistBrowsers" -ErrorAction SilentlyContinue
 }
 
 # Hide item selection checkboxes


### PR DESCRIPTION
Add three simple tweaks seen in folder options, that I actually use in some scenarios.
1) EnableFolderSeparateProcess / DisableFolderSeparateProcess:
- if a window crashes, doesn't take down the whole desktop and all other windows
2) EnableRestoreFolderWindows / DisableRestoreFolderWindows:
- windows kept opened during shutdown will open again after login
3)  DisableSharingWizard / EnableSharingWizard
- hides simple sharing setup, only classic "advanced" is available