### PR TITLE
Minor changes

### DIFF
--- a/Default.cmd
+++ b/Default.cmd
@@ -1,3 +1,1 @@
-@ECHO OFF
-
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Win10.ps1" -include "%~dp0Win10.psm1" -preset "%~dpn0.preset"
+@powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Win10.ps1" -include "%~dp0Win10.psm1" -preset "%~dpn0.preset"

--- a/Win10.psm1
+++ b/Win10.psm1
@@ -796,10 +796,14 @@ Function EnableUpdateRestart {
 # Stop and disable Home Groups services - Not applicable to 1803 and newer or Server
 Function DisableHomeGroups {
 	Write-Output "Stopping and disabling Home Groups services..."
-	Stop-Service "HomeGroupListener" -WarningAction SilentlyContinue
-	Set-Service "HomeGroupListener" -StartupType Disabled
-	Stop-Service "HomeGroupProvider" -WarningAction SilentlyContinue
-	Set-Service "HomeGroupProvider" -StartupType Disabled
+	If (Get-Service "HomeGroupListener" -ErrorAction SilentlyContinue) {
+		Stop-Service "HomeGroupListener" -WarningAction SilentlyContinue
+		Set-Service "HomeGroupListener" -StartupType Disabled
+	}
+	If (Get-Service "HomeGroupProvider" -ErrorAction SilentlyContinue) {
+		Stop-Service "HomeGroupProvider" -WarningAction SilentlyContinue
+		Set-Service "HomeGroupProvider" -StartupType Disabled
+	}
 }
 
 # Enable and start Home Groups services - Not applicable to 1803 and newer or Server


### PR DESCRIPTION
- shortened Default.cmd
- prevented annoying homegroup errors for 1803+ (counterpart for enabling not touched, cuz it's good to see the errors in this case imo)