### PR TITLE
[Add] DisableNTFSLastAccess

### DIFF
--- a/Default.preset
+++ b/Default.preset
@@ -68,6 +68,7 @@ DisableAutorun               # EnableAutorun
 # DisableDefragmentation     # EnableDefragmentation
 # DisableSuperfetch          # EnableSuperfetch
 # DisableIndexing            # EnableIndexing
+# DisableLastAccess          # EnableLastAccess
 # SetBIOSTimeUTC             # SetBIOSTimeLocal
 # EnableHibernation          # DisableHibernation
 # DisableSleepButton         # EnableSleepButton

--- a/Default.preset
+++ b/Default.preset
@@ -68,7 +68,7 @@ DisableAutorun               # EnableAutorun
 # DisableDefragmentation     # EnableDefragmentation
 # DisableSuperfetch          # EnableSuperfetch
 # DisableIndexing            # EnableIndexing
-# DisableLastAccess          # EnableLastAccess
+# DisableNTFSLastAccess      # EnableNTFSLastAccess
 # SetBIOSTimeUTC             # SetBIOSTimeLocal
 # EnableHibernation          # DisableHibernation
 # DisableSleepButton         # EnableSleepButton

--- a/Win10.psm1
+++ b/Win10.psm1
@@ -994,14 +994,14 @@ Function EnableIndexing {
 }
 
 # Disable the updating of the NTFS Last Access Time stamps
-Function DisableLastAccess {
+Function DisableNTFSLastAccess {
 	Write-Output "Disabling the updating of the Last Access Time stamps..."
 	# User Managed, Last Access Updates Disabled
 	fsutil behavior set DisableLastAccess 1 | Out-Null
 }
 
 # Enable the updating of the NTFS Last Access Time stamps
-Function EnableLastAccess {
+Function EnableNTFSLastAccess {
 	Write-Output "Enabling the updating of the Last Access Time stamps..."
 	If ([System.Environment]::OSVersion.Version.Build -ge 17134) {
 		# System Managed, Last Access Updates Enabled

--- a/Win10.psm1
+++ b/Win10.psm1
@@ -993,6 +993,25 @@ Function EnableIndexing {
 	Start-Service "WSearch" -WarningAction SilentlyContinue
 }
 
+# Disable the updating of the NTFS Last Access Time stamps
+Function DisableLastAccess {
+	Write-Output "Disabling the updating of the Last Access Time stamps..."
+	# User Managed, Last Access Updates Disabled
+	fsutil behavior set DisableLastAccess 1 | Out-Null
+}
+
+# Enable the updating of the NTFS Last Access Time stamps
+Function EnableLastAccess {
+	Write-Output "Enabling the updating of the Last Access Time stamps..."
+	If ([System.Environment]::OSVersion.Version.Build -ge 17134) {
+		# System Managed, Last Access Updates Enabled
+		fsutil behavior set DisableLastAccess 2 | Out-Null
+	} Else {
+		# Last Access Updates Enabled
+		fsutil behavior set DisableLastAccess 0 | Out-Null
+	}
+}
+
 # Set BIOS time to UTC
 Function SetBIOSTimeUTC {
 	Write-Output "Setting BIOS time to UTC..."


### PR DESCRIPTION
Windows stops updating Last Access attribute of files/dirs everytime they're touched. Positive side effect is saving I/O on HDDs. Windows seems to not doing it on SSDs already from some time.