### PR TITLE
error handling for missing registry keys

### DIFF
--- a/Win10.ps1
+++ b/Win10.ps1
@@ -40,4 +40,11 @@ While ($i -lt $args.Length) {
 }
 
 # Call the desired tweak functions
-$tweaks | ForEach-Object { Invoke-Expression $_ }
+try {
+	$tweaks | ForEach-Object { Invoke-Expression $_ }
+}
+catch [System.Management.Automation.ItemNotFoundException] {
+	$command = $error[0].InvocationInfo.Line # gets a reference to the offending line
+	New-Item -Path $_.TargetObject -Force # creates the missing registry keys
+	Invoke-Expression $command # runs the command that failed
+}


### PR DESCRIPTION
Hi there. This is only my second or third pull request, so please forgive me if I haven't done this properly.

This simple change to the code means that you won't need to check if a registry key exists before you write to it. It will really simplify the code in Win10.psm1 if you accept it. I can create a separate pull request eliminating the lines that start with "If (!(Test-Path " if you like.