### PR TITLE
UI and privacy updates (beta)

### DIFF
--- a/Default.preset
+++ b/Default.preset
@@ -27,8 +27,8 @@ DisableErrorReporting           # EnableErrorReporting
 # SetP2PUpdateLocal             # SetP2PUpdateInternet          # SetP2PUpdateDisable
 DisableDiagTrack                # EnableDiagTrack
 DisableWAPPush                  # EnableWAPPush
-# HideRecentJumplists           # ShowRecentJumplists
 # EnableClearRecentFiles        # DisableClearRecentFiles
+# DisableRecentFiles            # EnableRecentFiles
 
 ### Security Tweaks ###
 # SetUACLow                     # SetUACHigh
@@ -125,7 +125,6 @@ EnableNavPaneExpand             # DisableNavPaneExpand
 # HideSelectCheckboxes          # ShowSelectCheckboxes
 HideSyncNotifications           # ShowSyncNotifications
 HideRecentShortcuts             # ShowRecentShortcuts
-HideRecentFiles                 # ShowRecentFiles
 SetExplorerThisPC               # SetExplorerQuickAccess
 HideQuickAccess                 # ShowQuickAccess
 ShowThisPCOnDesktop             # HideThisPCFromDesktop

--- a/Default.preset
+++ b/Default.preset
@@ -28,6 +28,7 @@ DisableErrorReporting           # EnableErrorReporting
 DisableDiagTrack                # EnableDiagTrack
 DisableWAPPush                  # EnableWAPPush
 # HideRecentJumplists           # ShowRecentJumplists
+# EnableClearRecentFiles        # DisableClearRecentFiles
 
 ### Security Tweaks ###
 # SetUACLow                     # SetUACHigh
@@ -101,6 +102,7 @@ ShowTrayIcons                   # HideTrayIcons
 DisableSearchAppInStore         # EnableSearchAppInStore
 DisableNewAppPrompt             # EnableNewAppPrompt
 # HideRecentlyAddedApps         # ShowRecentlyAddedApps
+# HideMostUsedApps              # ShowMostUsedApps
 # SetControlPanelSmallIcons     # SetControlPanelLargeIcons     # SetControlPanelCategories
 DisableShortcutInName           # EnableShortcutInName
 # HideShortcutArrow             # ShowShortcutArrow
@@ -123,6 +125,7 @@ EnableNavPaneExpand             # DisableNavPaneExpand
 # HideSelectCheckboxes          # ShowSelectCheckboxes
 HideSyncNotifications           # ShowSyncNotifications
 HideRecentShortcuts             # ShowRecentShortcuts
+HideRecentFiles                 # ShowRecentFiles
 SetExplorerThisPC               # SetExplorerQuickAccess
 HideQuickAccess                 # ShowQuickAccess
 ShowThisPCOnDesktop             # HideThisPCFromDesktop

--- a/Win10.psm1
+++ b/Win10.psm1
@@ -437,31 +437,36 @@ Function EnableWAPPush {
 	Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\dmwappushservice" -Name "DelayedAutoStart" -Type DWord -Value 1
 }
 
-# Hide recently opened items in Jump Lists on Start or the taskbar
-Function HideRecentJumplists {
-	Write-Output "Hiding recently opened items in Jump Lists..."
-	Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "Start_TrackDocs" -Type DWord -Value 0
-}
-
-# Show recently opened items in Jump Lists on Start or the taskbar
-Function ShowRecentJumplists {
-	Write-Output "Showing recently opened items in Jump Lists..."
-	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "Start_TrackDocs" -ErrorAction SilentlyContinue
-}
-
-# Clear 'Recent files' list on exit
+# Enable clearing of recent files on exit
+# Empties most recently used (MRU) items lists such as 'Recent Items' menu on the Start menu, jump lists, and shortcuts at the bottom of the 'File' menu in applications during every logout.
 Function EnableClearRecentFiles {
-	Write-Output "Enabling the clearing of 'Recent files' on exit..."
+	Write-Output "Enabling clearing of recent files on exit..."
 	If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer")) {
 		New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" | Out-Null
 	}
 	Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "ClearRecentDocsOnExit" -Type DWord -Value 1
 }
 
-# Do not clear 'Recent files' list on exit
+# Disable clearing of recent files on exit
 Function DisableClearRecentFiles {
-	Write-Output "Disabling the clearing of 'Recent files' on exit..."
+	Write-Output "Disabling clearing of recent files on exit..."
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "ClearRecentDocsOnExit" -ErrorAction SilentlyContinue
+}
+
+# Disable recent files lists
+# Stops creating most recently used (MRU) items lists such as 'Recent Items' menu on the Start menu, jump lists, and shortcuts at the bottom of the 'File' menu in applications.
+Function DisableRecentFiles {
+	Write-Output "Disabling recent files lists..."
+	If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer")) {
+		New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" | Out-Null
+	}
+	Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoRecentDocsHistory" -Type DWord -Value 1
+}
+
+# Enable recent files lists
+Function EnableRecentFiles {
+	Write-Output "Enabling recent files lists..."
+	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoRecentDocsHistory" -ErrorAction SilentlyContinue
 }
 
 ##########
@@ -1540,18 +1545,18 @@ Function ShowRecentlyAddedApps {
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideRecentlyAddedApps" -ErrorAction SilentlyContinue
 }
 
-# Remove 'Most used' apps list from the Start Menu
+# Hide 'Most used' apps list from the Start Menu - Applicable until 1703 (hidden by default since then)
 Function HideMostUsedApps {
-	Write-Output "Hiding 'Most used' apps list from the Start Menu......"
+	Write-Output "Hiding 'Most used' apps list from the Start Menu..."
 	If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer")) {
 		New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" | Out-Null
 	}
 	Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoStartMenuMFUprogramsList" -Type DWord -Value 1
 }
 
-# Show 'Most used' apps list in the Start Menu
+# Show 'Most used' apps list in the Start Menu - Applicable until 1703 (GPO broken since then)
 Function ShowMostUsedApps {
-	Write-Output "Showing 'Most used' apps list in the Start Menu......"
+	Write-Output "Showing 'Most used' apps list in the Start Menu..."
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoStartMenuMFUprogramsList" -ErrorAction SilentlyContinue
 }
 
@@ -1884,32 +1889,18 @@ Function ShowSyncNotifications {
 }
 
 # Hide recently and frequently used item shortcuts in Explorer
+# Note: This is only UI tweak to hide the shortcuts. In order to stop creating most recently used (MRU) items lists everywhere, use privacy tweak 'DisableRecentFiles' instead.
 Function HideRecentShortcuts {
-	Write-Output "Hiding recent shortcuts..."
+	Write-Output "Hiding recent shortcuts in Explorer..."
 	Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer" -Name "ShowRecent" -Type DWord -Value 0
 	Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer" -Name "ShowFrequent" -Type DWord -Value 0
 }
 
 # Show recently and frequently used item shortcuts in Explorer
 Function ShowRecentShortcuts {
-	Write-Output "Showing recent shortcuts..."
+	Write-Output "Showing recent shortcuts in Explorer..."
 	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer" -Name "ShowRecent" -ErrorAction SilentlyContinue
 	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer" -Name "ShowFrequent" -ErrorAction SilentlyContinue
-}
-
-# Hide 'Recent files' list
-Function HideRecentFiles {
-	Write-Output "Hiding 'Recent files' list..."
-	If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer")) {
-		New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" | Out-Null
-	}
-	Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoRecentDocsHistory" -Type DWord -Value 1
-}
-
-# Show 'Recent files' list
-Function ShowRecentFiles {
-	Write-Output "Showing 'Recent files' list..."
-	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoRecentDocsHistory" -ErrorAction SilentlyContinue
 }
 
 # Change default Explorer view to This PC

--- a/Win10.psm1
+++ b/Win10.psm1
@@ -449,6 +449,21 @@ Function ShowRecentJumplists {
 	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "Start_TrackDocs" -ErrorAction SilentlyContinue
 }
 
+# Clear 'Recent files' list on exit
+Function EnableClearRecentFiles {
+	Write-Output "Enabling the clearing of 'Recent files' on exit..."
+	If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer")) {
+		New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" | Out-Null
+	}
+	Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "ClearRecentDocsOnExit" -Type DWord -Value 1
+}
+
+# Do not clear 'Recent files' list on exit
+Function DisableClearRecentFiles {
+	Write-Output "Disabling the clearing of 'Recent files' on exit..."
+	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "ClearRecentDocsOnExit" -ErrorAction SilentlyContinue
+}
+
 ##########
 #endregion Privacy Tweaks
 ##########
@@ -1510,19 +1525,34 @@ Function EnableNewAppPrompt {
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "NoNewAppAlert" -ErrorAction SilentlyContinue
 }
 
-# Hide 'Recently added' list from Start Menu
+# Hide 'Recently added' list from the Start Menu
 Function HideRecentlyAddedApps {
-	Write-Output "Hiding 'Recently added' list from Start Menu..."
+	Write-Output "Hiding 'Recently added' list from the Start Menu..."
 	If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer")) {
 		New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" | Out-Null
 	}
 	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideRecentlyAddedApps" -Type DWord -Value 1
 }
 
-# Show 'Recently added' list in Start Menu
+# Show 'Recently added' list in the Start Menu
 Function ShowRecentlyAddedApps {
-	Write-Output "Showing 'Recently added' list in Start Menu..."
+	Write-Output "Showing 'Recently added' list in the Start Menu..."
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideRecentlyAddedApps" -ErrorAction SilentlyContinue
+}
+
+# Remove 'Most used' apps list from the Start Menu
+Function HideMostUsedApps {
+	Write-Output "Hiding 'Most used' apps list from the Start Menu......"
+	If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer")) {
+		New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" | Out-Null
+	}
+	Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoStartMenuMFUprogramsList" -Type DWord -Value 1
+}
+
+# Show 'Most used' apps list in the Start Menu
+Function ShowMostUsedApps {
+	Write-Output "Showing 'Most used' apps list in the Start Menu......"
+	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoStartMenuMFUprogramsList" -ErrorAction SilentlyContinue
 }
 
 # Set Control Panel view to Small icons (Classic)
@@ -1865,6 +1895,21 @@ Function ShowRecentShortcuts {
 	Write-Output "Showing recent shortcuts..."
 	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer" -Name "ShowRecent" -ErrorAction SilentlyContinue
 	Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer" -Name "ShowFrequent" -ErrorAction SilentlyContinue
+}
+
+# Hide 'Recent files' list
+Function HideRecentFiles {
+	Write-Output "Hiding 'Recent files' list..."
+	If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer")) {
+		New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" | Out-Null
+	}
+	Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoRecentDocsHistory" -Type DWord -Value 1
+}
+
+# Show 'Recent files' list
+Function ShowRecentFiles {
+	Write-Output "Showing 'Recent files' list..."
+	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoRecentDocsHistory" -ErrorAction SilentlyContinue
 }
 
 # Change default Explorer view to This PC


### PR DESCRIPTION
I tested all of these tweaks in Windows 10 Pro 1809. I named the title "beta" as there are some questions left.

1) EnableClearRecentFiles / DisableClearRecentFiles
GPO to enable clearing of 'Recent files' list (shortcuts of recently used files).

2) HideMostUsedApps / ShowMostUsedApps
GPO to disable 'Most used' list in the start menu. Makes 'Show most used apps' switch greyed out even if 'Let Windows track apps...' is enabled.  There was a mention in  #110 about NoStartMenuMFUprogramsList was no longer valid in 1803, but I tried in 1809 and it seems to work fine.

3) HideRecentFiles / ShowRecentFiles
Similar (overlapping) to HideRecentShortcuts, except this is only for recently used files (not frequently used folders), but it's a GPO setting. Makes 'Show recently used files...' checkbox unchecked. Users can check the checkbox, but it has no effect and after reopening 'Folder Options' window the checkbox is unchecked again. I didn't touch the HideRecentShortcuts tweak, I'll rather wait what you'll think about all of this stuff. ;)

Cosmetic: I added "the" before "Start menu" to ShowRecentlyAddedApps tweak as I saw it in gpedit's description.