### PR TITLE
Prevents Windows 10 prompting to setup a pin after being added to Azure AD

### DIFF
--- a/Win10.psm1
+++ b/Win10.psm1
@@ -915,6 +915,9 @@ Function DisableSharedExperiences {
 	Write-Output "Disabling Shared Experiences..."
 	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableCdp" -Type DWord -Value 0
 	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableMmx" -Type DWord -Value 0
+	# Workaround to prevent dropping unsaved start menu caches which could be otherwise caused by this tweak.
+	# See https://github.com/Disassembler0/Win10-Initial-Setup-Script/issues/145 for details
+	Stop-Process -Name "ShellExperienceHost" -Force -ErrorAction SilentlyContinue
 }
 
 # Enable Shared Experiences - Not applicable to Server

--- a/Win10.psm1
+++ b/Win10.psm1
@@ -910,21 +910,17 @@ Function EnableHomeGroups {
 	Start-Service "HomeGroupProvider" -WarningAction SilentlyContinue
 }
 
-# Disable Shared Experiences - Not applicable to Server
+# Disable Shared Experiences - Applicable since 1703. Not applicable to Server
+# This setting can be set also via GPO, however doing so causes reset of Start Menu cache. See https://github.com/Disassembler0/Win10-Initial-Setup-Script/issues/145 for details
 Function DisableSharedExperiences {
 	Write-Output "Disabling Shared Experiences..."
-	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableCdp" -Type DWord -Value 0
-	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableMmx" -Type DWord -Value 0
-	# Workaround to prevent dropping unsaved Start Menu caches which could be otherwise caused by this tweak. Any changes in Start Menu made after application of this tweak may be lost.
-	# See https://github.com/Disassembler0/Win10-Initial-Setup-Script/issues/145 for details
-	Stop-Process -Name "ShellExperienceHost" -Force -ErrorAction SilentlyContinue
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\CDP" -Name "RomeSdkChannelUserAuthzPolicy" -Type DWord -Value 0
 }
 
-# Enable Shared Experiences - Not applicable to Server
+# Enable Shared Experiences - Applicable since 1703. Not applicable to Server
 Function EnableSharedExperiences {
 	Write-Output "Enabling Shared Experiences..."
-	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableCdp" -ErrorAction SilentlyContinue
-	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableMmx" -ErrorAction SilentlyContinue
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\CDP" -Name "RomeSdkChannelUserAuthzPolicy" -Type DWord -Value 1
 }
 
 # Disable Remote Assistance - Not applicable to Server (unless Remote Assistance is explicitly installed)

--- a/Win10.psm1
+++ b/Win10.psm1
@@ -915,7 +915,7 @@ Function DisableSharedExperiences {
 	Write-Output "Disabling Shared Experiences..."
 	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableCdp" -Type DWord -Value 0
 	Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableMmx" -Type DWord -Value 0
-	# Workaround to prevent dropping unsaved start menu caches which could be otherwise caused by this tweak.
+	# Workaround to prevent dropping unsaved Start Menu caches which could be otherwise caused by this tweak. Any changes in Start Menu made after application of this tweak may be lost.
 	# See https://github.com/Disassembler0/Win10-Initial-Setup-Script/issues/145 for details
 	Stop-Process -Name "ShellExperienceHost" -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
This is one of the annoying feature of Windows 10 on O365 Azure AD bind PC. 
By the way your script is really amazing, I have managed to save thousands of minutes in tweaks. Just run it and off I go.. 
Thankyou for sharing. 

```
####################################################################################
#
#  Ian Waters
#
#  www.slashadmin.co.uk
#
#  Prevents Windows 10 prompting to setup a pin after being added to Azure AD
#
#  Designed for use with Office 365 Business Premium subscriptions
#
####################################################################################


#Disable pin requirement
$path = "HKLM:\SOFTWARE\Policies\Microsoft"
$key = "PassportForWork"
$name = "Enabled"
$value = "0"

New-Item -Path $path -Name $key –Force

New-ItemProperty -Path $path\$key -Name $name -Value $value -PropertyType DWORD -Force

#Delete existing pins
$passportFolder = "C:\Windows\ServiceProfiles\LocalService\AppData\Local\Microsoft\Ngc"

if(Test-Path -Path $passportFolder)
{
    Takeown /f $passportFolder /r /d "Y"
    ICACLS $passportFolder /reset /T /C /L /Q

    Remove-Item –path $passportFolder –recurse -force
}
```