### PR TITLE
Added call variant with output redirection in .cmd

### DIFF
--- a/Default.cmd
+++ b/Default.cmd
@@ -1,1 +1,7 @@
-@powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Win10.ps1" -include "%~dp0Win10.psm1" -preset "%~dpn0.preset"
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0Win10.ps1" -include "%~dp0Win10.psm1" -preset "%~dpn0.preset"
+
+rem The following variant redirects output also to a file
+rem Usage: Default.cmd foo.log
+rem Works only if already started as admin (RequireAdmin in .preset can't be used)
+rem powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "&"'%~dp0Win10.ps1' -include '%~dp0Win10.psm1' -preset '%~dpn0.preset' "2>&1 | Tee-Object" -FilePath '%1'


### PR DESCRIPTION
Alternative way to call the script. Stdout and stderr is redirected with Tee-object.
Added as a comment/hint for people who wants to use it that way.

It requires Default.cmd to be already started as admin. RequireAdmin does not work.
Tested with Win7 64bit, PowerShell 2.0 and Win10 1809 64bit, PowerShell 5.1.
Handles spaces in pathes and file names.