### PR TITLE
Add option to show Windows build number on desktop

### DIFF
--- a/Default.preset
+++ b/Default.preset
@@ -127,7 +127,7 @@ SetVisualFXPerformance          # SetVisualFXAppearance
 # DisableChangingSoundScheme    # EnableChangingSoundScheme
 # EnableVerboseStatus           # DisableVerboseStatus
 DisableF1HelpKey                # EnableF1HelpKey
-ShowBuildNumberOnDesktop        # HideBuildNumberOnDesktop
+# ShowBuildNumberOnDesktop      # HideBuildNumberOnDesktop
 
 ### Explorer UI Tweaks ###
 # ShowExplorerTitleFullPath     # HideExplorerTitleFullPath

--- a/Default.preset
+++ b/Default.preset
@@ -127,6 +127,7 @@ SetVisualFXPerformance          # SetVisualFXAppearance
 # DisableChangingSoundScheme    # EnableChangingSoundScheme
 # EnableVerboseStatus           # DisableVerboseStatus
 DisableF1HelpKey                # EnableF1HelpKey
+ShowBuildNumberOnDesktop        # HideBuildNumberOnDesktop
 
 ### Explorer UI Tweaks ###
 # ShowExplorerTitleFullPath     # HideExplorerTitleFullPath

--- a/Win10.psm1
+++ b/Win10.psm1
@@ -1998,6 +1998,16 @@ Function EnableF1HelpKey {
 	Remove-Item "HKCU:\Software\Classes\TypeLib\{8cec5860-07a1-11d9-b15e-000d56bfe6ee}\1.0\0" -Recurse -ErrorAction SilentlyContinue
 }
 
+# Show Windows build number and Windows edition (Home/Pro/Enterprise) from bottom right of desktop
+Function ShowBuildNumberOnDesktop {
+	Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "PaintDesktopVersion" -Type DWord -Value 1
+}
+
+# Remove Windows build number and Windows edition (Home/Pro/Enterprise) from bottom right of desktop
+Function HideBuildNumberOnDesktop {
+	Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "PaintDesktopVersion" -Type DWord -Value 0
+}
+
 ##########
 #endregion UI Tweaks
 ##########


### PR DESCRIPTION
As an example, what is shown on my own setup:

Windows 10 Enterprise N
Build 18362.19h1_release.190318-1202
![image](https://user-images.githubusercontent.com/479129/61571399-9a784b00-aa93-11e9-8225-3a15f51930c6.png)

I wish I knew how to remove the "Merge pull request" commits from the pull request, sorry about that.
Added the new function as default, since it's my personal preference