### PR TITLE
Disable Microsoft Office 2019 telemetry

### DIFF
--- a/Win10.psm1
+++ b/Win10.psm1
@@ -54,6 +54,9 @@ Function DisableTelemetry {
 	Disable-ScheduledTask -TaskName "Microsoft\Windows\Customer Experience Improvement Program\Consolidator" | Out-Null
 	Disable-ScheduledTask -TaskName "Microsoft\Windows\Customer Experience Improvement Program\UsbCeip" | Out-Null
 	Disable-ScheduledTask -TaskName "Microsoft\Windows\DiskDiagnostic\Microsoft-Windows-DiskDiagnosticDataCollector" | Out-Null
+	Disable-ScheduledTask -TaskName "Microsoft\Office\Office ClickToRun Service Monitor" | Out-Null
+	Disable-ScheduledTask -TaskName "Microsoft\Office\OfficeTelemetryAgentFallBack2016" | Out-Null
+	Disable-ScheduledTask -TaskName "Microsoft\Office\OfficeTelemetryAgentLogOn2016" | Out-Null
 }
 
 # Enable Telemetry
@@ -76,6 +79,9 @@ Function EnableTelemetry {
 	Enable-ScheduledTask -TaskName "Microsoft\Windows\Customer Experience Improvement Program\Consolidator" | Out-Null
 	Enable-ScheduledTask -TaskName "Microsoft\Windows\Customer Experience Improvement Program\UsbCeip" | Out-Null
 	Enable-ScheduledTask -TaskName "Microsoft\Windows\DiskDiagnostic\Microsoft-Windows-DiskDiagnosticDataCollector" | Out-Null
+	Enable-ScheduledTask -TaskName "Microsoft\Office\Office ClickToRun Service Monitor" | Out-Null
+	Enable-ScheduledTask -TaskName "Microsoft\Office\OfficeTelemetryAgentFallBack2016" | Out-Null
+	Enable-ScheduledTask -TaskName "Microsoft\Office\OfficeTelemetryAgentLogOn2016" | Out-Null
 }
 
 # Disable Wi-Fi Sense


### PR DESCRIPTION
Disable the following scheduled tasks responsible for scanning and uploading
user data to Microsoft.

Office ClickToRun Service Monitor: This task monitors the state of your
Microsoft Office ClickToRunSvc and sends crash and error logs to Microsoft.

OfficeTelemetryAgentLogOn2016: This task initiates Office Telemetry Agent,
which scans and uploads usage and error information for Office solutions when
a user logs on to the computer.

OfficeTelemetryAgentFallBack2016: This task initiates the background task for
Office Telemetry Agent, which scans and uploads usage and error information
for Office solutions.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>