### PR TITLE
Add EnableLoopback and DisableLoopback

### DIFF
--- a/Win10.psm1
+++ b/Win10.psm1
@@ -4078,6 +4078,27 @@ Function UnpinTaskbarIcons {
 
 
 ##########
+#region UWP Loopback
+##########
+
+# Disable Loopback
+Function DisableLoopback{
+	Write-Output "Disabling Loopback..."
+	CheckNetIsolation LoopbackExempt –c | Out-Null
+}
+
+# Enable Loopback
+Function EnableLoopback{
+	Write-Output "Enabling Loopback..."
+	Get-AppxPackage | select-object -ExpandProperty PackageFamilyName | ForEach-Object -Process {CheckNetIsolation LoopbackExempt –a –n=$_} | Out-Null
+}
+
+##########
+#endregion UWP Loopback
+##########
+
+
+##########
 #region Auxiliary Functions
 ##########
 


### PR DESCRIPTION
Windows 10 UWP apps can't connect to local IP (loopback restriction) Windows 10 UWP apps by default are restricted from connecting to the local IP (loopback restriction).
This script can help release this restriction for all UWP Apps or restore the default status.