### PR TITLE
Add functions to change what happens when a laptop lid is closed

### DIFF
--- a/Default.preset
+++ b/Default.preset
@@ -116,6 +116,7 @@ EnableNTFSLongPaths             # DisableNTFSLongPaths
 # EnableHibernation             # DisableHibernation
 # DisableSleepButton            # EnableSleepButton
 # DisableSleepTimeout           # EnableSleepTimeout
+# SetLidActionNone              # SetLidActionSleep             # SetLidActionHibernate         # SetLidActionShutDown
 # DisableFastStartup            # EnableFastStartup
 # DisableAutoRebootOnCrash      # EnableAutoRebootOnCrash
 

--- a/Win10.psm1
+++ b/Win10.psm1
@@ -1765,6 +1765,30 @@ Function EnableSleepTimeout {
 	powercfg /X standby-timeout-dc 15
 }
 
+# Set lid closing action to Do Nothing
+Function SetLidActionNone {
+	Write-Output "Setting lid closing action to Do Nothing..."
+	powercfg /SETACVALUEINDEX SCHEME_CURRENT SUB_BUTTONS LIDACTION 0
+}
+
+# Set lid closing action to Sleep
+Function SetLidActionSleep {
+	Write-Output "Setting lid closing action to Sleep..."
+	powercfg /SETACVALUEINDEX SCHEME_CURRENT SUB_BUTTONS LIDACTION 1
+}
+
+# Set lid closing action to Hibernate
+Function SetLidActionHibernate {
+	Write-Output "Setting lid closing action to Hibernate..."
+	powercfg /SETACVALUEINDEX SCHEME_CURRENT SUB_BUTTONS LIDACTION 2
+}
+
+# Set lid closing action to Shut Down
+Function SetLidActionShutDown {
+	Write-Output "Setting lid closing action to Shut Down..."
+	powercfg /SETACVALUEINDEX SCHEME_CURRENT SUB_BUTTONS LIDACTION 3
+}
+
 # Disable Fast Startup
 Function DisableFastStartup {
 	Write-Output "Disabling Fast Startup..."


### PR DESCRIPTION
I need to set this to None on all my fresh Windows installations, so at least the 'Do Nothing' function would be very helpful.
If you don't want to have all four varieties, I would at least suggest to keep the 'Do Nothing' and 'Sleep' ones.

Reference: https://docs.microsoft.com/de-de/windows-hardware/customize/power-settings/power-button-and-lid-settings-lid-switch-close-action